### PR TITLE
Bigger readability changes

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use pest::prelude::*;
 use errors::Result;
 
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 /// All operators can appear in Tera templates
 pub enum Operator {
     /// +


### PR DESCRIPTION
Sematically it's a few small changes, but it affected a very large number of lines. The general idea was that I transformed 

```
match node {
    NodeType(ref values) => {
        // Lots of stuff
    },
    _ => unreachable!(),
}
```

into this to reduce rightward drift:

```
let (values) = match node {
    NodeType(ref values) => (values),
    _ => unreachable!(),
}

// Lots of stuff
```

Let me know what you think :) 